### PR TITLE
Feature: allow the card customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ In html
 
 **Base URL** - https://readme-quote-api.vercel.app/
 
-| EndPoint         | Returns                                            |
-| ---------------- | -------------------------------------------------- |
-| /                | Hello Page in API                                  |
-| /quote           | A random quote in rendered SVG form                |
-| /quote?type=json | Quote in json format                               |
-| /all             | All quotes in JSON format within a single response |
+| EndPoint                | Returns                                                       |
+| ----------------------- | ------------------------------------------------------------- |
+| /                       | Hello Page in API                                             |
+| /quote                  | A random quote in rendered SVG form                           |
+| /quote?textColor=242b2e | Hex color for the card text                                   |
+| /quote?bgColor=fff      | Hex color for the card background                             |
+| /quote?borderColor=f00d | Hex color for the card border                                 |
+| /quote?hideBorder=false | Boolean indicating whether the border should be hidden or not |
+| /quote?type=json        | Quote in json format                                          |
+| /all                    | All quotes in JSON format within a single response            |
 
 ## Contribution Guidelines
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ const theme = require("./src/themes.json");
 /* ---- Importing Card template ---- */
 const { quoteCard } = require("./src/quoteCard");
 
+/* ---- Importing utility functions ---- */
+const { isValidHexColor } = require("./src/utils");
+
 /* ---- Handling get requests on all routes ----*/
 app.get("/", async (req, res) => {
   res.send(
@@ -40,13 +43,27 @@ app.get("/quote", async (req, res) => {
 
     const quote = `${quoteObject.quote} - ${quoteObject.author}`;
 
+    /* ---- Calculate card parameters based on query values ---- */
+    const textColor = isValidHexColor(query.textColor)
+      ? `#${query.textColor}`
+      : theme.dark.textColor;
+    const bgColor = isValidHexColor(query.bgColor)
+      ? `#${query.bgColor}`
+      : theme.dark.bg;
+    const borderColor = isValidHexColor(query.borderColor)
+      ? `#${query.borderColor}`
+      : theme.dark.borderColor;
+    const hideBorder = query.hideBorder
+      ? query.hideBorder === "true"
+      : theme.dark.hideBorder;
+
     /* ---- Setting up card properties,data---- */
     let card = quoteCard(
-      theme.dark.textColor,
-      theme.dark.bg,
-      theme.dark.border,
+      textColor,
+      bgColor,
+      borderColor,
       quote,
-      theme.dark.hodeBorder
+      hideBorder
     );
 
     /* ----- Sets the type of content sent  ----- */

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+function isValidHexColor(hexColor) {
+  return new RegExp(
+    /^([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{4})$/
+  ).test(hexColor);
+}
+
+module.exports = { isValidHexColor };


### PR DESCRIPTION
Hello! :wave: 
I'd like to contribute with this PR which allows the users to customize their card by:
- Text color
- Background color
- Border color
- Showing/hiding the border

All of these customizations are passed by the query parameters. So a request to
`https://readme-quote-api.vercel.app/quote?textColor=800080&hideBorder=false&bgColor=ff0&borderColor=f00` should return the following card:
![image](https://user-images.githubusercontent.com/42191629/195422002-e47a4e8e-f4db-4e1f-9d95-ea1cfa45035a.png)
